### PR TITLE
Navigation: Require specifying of the NavigationDriver implementation

### DIFF
--- a/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
+++ b/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.viewbinding.ViewBinding
 import io.matthewnelson.concept_navigation.NavigationRequest
+import io.matthewnelson.feature_navigation.NavigationDriver
 import kotlinx.coroutines.flow.collect
 
 /**
@@ -33,7 +34,8 @@ import kotlinx.coroutines.flow.collect
  * */
 abstract class NavigationActivity<
         VM: ViewModel,
-        NVM: NavigationViewModel,
+        D: NavigationDriver<NavController>,
+        NVM: NavigationViewModel<D>,
         VB: ViewBinding
         >(@LayoutRes layoutId: Int): AppCompatActivity(layoutId)
 {

--- a/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationViewModel.kt
+++ b/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationViewModel.kt
@@ -18,6 +18,6 @@ package io.matthewnelson.android_feature_activity
 import androidx.navigation.NavController
 import io.matthewnelson.feature_navigation.NavigationDriver
 
-interface NavigationViewModel {
-    val navigationDriver: NavigationDriver<NavController>
+interface NavigationViewModel<T: NavigationDriver<NavController>> {
+    val navigationDriver: T
 }


### PR DESCRIPTION
This PR updates the `android-feature-activity` by requiring specification of the `NavigationDriver` implementation in both the `NavigationActivity` and `NavigationViewModel`.