### PR TITLE
Move background login business logic to manager

### DIFF
--- a/kotlin/concepts/authentication/concept-authentication-core/src/main/java/io/matthewnelson/concept_authentication_core/AuthenticationManager.kt
+++ b/kotlin/concepts/authentication/concept-authentication-core/src/main/java/io/matthewnelson/concept_authentication_core/AuthenticationManager.kt
@@ -22,6 +22,7 @@ import io.matthewnelson.concept_authentication_core.model.ConfirmUserInputToRese
 import io.matthewnelson.concept_authentication_core.model.ConfirmUserInputToSetForFirstTime
 import io.matthewnelson.concept_authentication_core.model.UserInput
 import io.matthewnelson.concept_foreground_state.ForegroundStateManager
+import io.matthewnelson.k_openssl_common.clazzes.Password
 import kotlinx.coroutines.flow.Flow
 
 abstract class AuthenticationManager<
@@ -43,6 +44,7 @@ abstract class AuthenticationManager<
      * then attempt to log in. See [AuthenticationRequest.LogIn] for more information.
      * */
     abstract fun authenticate(
+        privateKey: Password,
         request: AuthenticationRequest.LogIn
     ): Flow<AuthenticationResponse>
 

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreCoordinator.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreCoordinator.kt
@@ -78,30 +78,9 @@ abstract class AuthenticationCoreCoordinator(
                 // If encryptionKey value is null, proceed with the regular checks and send
                 // user to Authentication View if needed, otherwise try logging in here
                 // w/o sending the user to the Authentication View.
-                request.privateKey?.let { requestPassword ->
+                request.privateKey?.let { privateKey ->
 
-                    authenticationManager.getEncryptionKey()?.let { alreadySetKey ->
-
-                        // Ensure an already set key is compared first before returning success
-                        if (!alreadySetKey.privateKey.compare(requestPassword)) {
-                            return flowOf(
-                                AuthenticationResponse.Failure(request)
-                            )
-                        }
-
-                        // If the AuthenticationState doesn't need to be updated, can return
-                        // success here with the already set key.
-                        if (
-                            authenticationManager.authenticationStateFlow.value
-                                    is AuthenticationState.NotRequired
-                        ) {
-                            return flowOf(
-                                AuthenticationResponse.Success.Key(request, alreadySetKey)
-                            )
-                        }
-                    }
-
-                    return authenticationManager.authenticate(request)
+                    return authenticationManager.authenticate(privateKey, request)
 
                 } ?: when (authenticationManager.authenticationStateFlow.value) {
                     is AuthenticationState.NotRequired -> {

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
@@ -245,8 +245,7 @@ abstract class AuthenticationCoreManager(
     private var encryptionKey: EncryptionKey? = null
     private val encryptionKeyLock = Object()
 
-    @JvmSynthetic
-    internal fun getEncryptionKey(): EncryptionKey? =
+    fun getEncryptionKey(): EncryptionKey? =
         synchronized(encryptionKeyLock) {
             encryptionKey
         }


### PR DESCRIPTION
This PR moves the business logic for the background login feature to the `AuthenticationCoreManager` class so that background logins can happen via the application (Singleton) scope w/o need to rely on an activity being present.