### PR TITLE
Add Open to AuthenticationPrefs to override if desired

### DIFF
--- a/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/AuthenticationCoreStorageAndroid.kt
+++ b/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/AuthenticationCoreStorageAndroid.kt
@@ -32,7 +32,7 @@ open class AuthenticationCoreStorageAndroid(
     protected val dispatchers: CoroutineDispatchers
 ): AuthenticationCoreStorage() {
 
-    protected val authenticationPrefs: SharedPreferences by lazy {
+    protected open val authenticationPrefs: SharedPreferences by lazy {
         EncryptedSharedPreferences.create(
             context.applicationContext,
             authenticationSharedPrefsName.value,

--- a/kotlin/test/test-feature-authentication-core/src/main/java/io/matthewnelson/test_feature_authentication_core/AuthenticationCoreTestHelper.kt
+++ b/kotlin/test/test-feature-authentication-core/src/main/java/io/matthewnelson/test_feature_authentication_core/AuthenticationCoreTestHelper.kt
@@ -69,7 +69,7 @@ abstract class AuthenticationCoreTestHelper<
      * */
     protected suspend fun login(): AuthenticationResponse {
         val writer = testCoreManager.getNewUserInput()
-        repeat(8) {
+        repeat(testInitializer.minimumUserInputLength) {
             writer.addCharacter('0')
         }
 


### PR DESCRIPTION
This PR adds the open class modifier to the `authenticationPrefs` variable such that inheriting classes can override the defaults. This makes testing much easier as it can be swapped out for the regular Android SharedPreferences framework, as we are not testing `EncryptedSharedPreferences`.