### PR TITLE
Adds Input Lock checking to methods

### DIFF
--- a/kotlin/features/authentication/feature-authentication-view/src/main/java/io/matthewnelson/feature_authentication_view/ui/AuthenticationViewModelContainer.kt
+++ b/kotlin/features/authentication/feature-authentication-view/src/main/java/io/matthewnelson/feature_authentication_view/ui/AuthenticationViewModelContainer.kt
@@ -188,9 +188,11 @@ class AuthenticationViewModelContainer<T>(
         }
     }
 
-    fun confirmPress() {
-        viewModelScope.launch(dispatchers.mainImmediate) {
-            eventHandler.produceHapticFeedback()
+    fun confirmPress(produceHapticFeedback: Boolean = true) {
+        if (produceHapticFeedback) {
+            viewModelScope.launch(dispatchers.mainImmediate) {
+                eventHandler.produceHapticFeedback()
+            }
         }
 
         if (confirmPressJob?.isActive == true) {

--- a/kotlin/features/authentication/feature-authentication-view/src/main/java/io/matthewnelson/feature_authentication_view/ui/AuthenticationViewModelContainer.kt
+++ b/kotlin/features/authentication/feature-authentication-view/src/main/java/io/matthewnelson/feature_authentication_view/ui/AuthenticationViewModelContainer.kt
@@ -156,6 +156,10 @@ class AuthenticationViewModelContainer<T>(
             eventHandler.produceHapticFeedback()
         }
 
+        if (viewStateContainer.value.inputLockState.show) {
+            return
+        }
+
         try {
             userInput.dropLastCharacter()
         } catch (e: IllegalArgumentException) {
@@ -169,6 +173,10 @@ class AuthenticationViewModelContainer<T>(
     fun numPadPress(c: Char): Boolean {
         viewModelScope.launch(dispatchers.mainImmediate) {
             eventHandler.produceHapticFeedback()
+        }
+
+        if (viewStateContainer.value.inputLockState.show) {
+            return false
         }
 
         return try {


### PR DESCRIPTION
This PR adds input lock checking to the `feature-authentication-view` module's `numPadPress` and `backSpacePress` methods such that the pin value being run through `AuthenticationManager` remains unaltered while it's processing the credentials.

It also adds the option to signal for producing haptic feedback on confirm press or not.