### PR TITLE
Refactor: AuthenticationCore

### DIFF
--- a/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/components/AuthenticationCoreManagerAndroid.kt
+++ b/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/components/AuthenticationCoreManagerAndroid.kt
@@ -19,7 +19,6 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.os.SystemClock
-import androidx.annotation.MainThread
 import io.matthewnelson.feature_authentication_core.AuthenticationCoreManager
 import io.matthewnelson.concept_authentication.state.AuthenticationState
 import io.matthewnelson.concept_foreground_state.ForegroundState
@@ -97,7 +96,7 @@ abstract class AuthenticationCoreManagerAndroid(
                 backgroundLogOutTime > 0L &&
                 (SystemClock.uptimeMillis() - timeMovedToBackground) > backgroundLogOutTime
             ) {
-                updateAuthenticationState(AuthenticationState.Required.LoggedOut)
+                setAuthenticationStateRequired(AuthenticationState.Required.LoggedOut)
             }
         }
         changingConfigurations = false
@@ -131,7 +130,7 @@ abstract class AuthenticationCoreManagerAndroid(
         ) {
             onApplicationClearedFromRecentsTray(activity)
             if (logOutWhenApplicationIsClearedFromRecentsTray) {
-                updateAuthenticationState(AuthenticationState.Required.InitialLogIn)
+                setAuthenticationStateRequired(AuthenticationState.Required.InitialLogIn)
             }
         }
     }

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
@@ -97,7 +97,7 @@ abstract class AuthenticationCoreManager(
      * */
     protected open fun onInitialLoginSuccess(encryptionKey: EncryptionKey) {}
 
-    protected fun updateAuthenticationState(state: AuthenticationState) {
+    protected fun setAuthenticationStateRequired(state: AuthenticationState.Required) {
         updateAuthenticationState(state, null)
     }
 

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/AuthenticationCoreManager.kt
@@ -65,16 +65,37 @@ abstract class AuthenticationCoreManager(
 
     @JvmSynthetic
     @Suppress("UNUSED_PARAMETER")
-    internal fun updateAuthenticationState(state: AuthenticationState, any: Any?) {
+    @Throws(IllegalArgumentException::class)
+    internal fun updateAuthenticationState(
+        state: AuthenticationState,
+        encryptionKey: EncryptionKey?
+    ) {
         @Exhaustive
         when (state) {
-            is AuthenticationState.NotRequired -> {}
+            is AuthenticationState.NotRequired -> {
+                encryptionKey?.let { nnKey ->
+                    setEncryptionKey(nnKey)
+
+                    if (_authenticationStateFlow.value == AuthenticationState.Required.InitialLogIn) {
+                        onInitialLoginSuccess(nnKey)
+                    }
+
+                } ?: throw IllegalArgumentException(
+                    "An EncryptionKey is required when setting AuthenticationState to NotRequired "
+                )
+            }
             is AuthenticationState.Required -> {
                 setEncryptionKey(null)
             }
         }
         _authenticationStateFlow.value = state
     }
+
+    /**
+     * Called when [AuthenticationState] transitions from [AuthenticationState.Required.InitialLogIn]
+     * to [AuthenticationState.NotRequired]
+     * */
+    protected open fun onInitialLoginSuccess(encryptionKey: EncryptionKey) {}
 
     protected fun updateAuthenticationState(state: AuthenticationState) {
         updateAuthenticationState(state, null)
@@ -264,12 +285,38 @@ abstract class AuthenticationCoreManager(
             }
         }
 
-    @JvmSynthetic
-    internal fun setEncryptionKey(encryptionKey: EncryptionKey?) {
+    private fun setEncryptionKey(encryptionKey: EncryptionKey?) {
         synchronized(encryptionKeyLock) {
-            this.encryptionKey?.privateKey?.clear()
-            this.encryptionKey?.publicKey?.clear()
-            this.encryptionKey = encryptionKey
+
+            // clear key if passed value is null
+            if (encryptionKey == null) {
+                this.encryptionKey?.privateKey?.clear()
+                this.encryptionKey?.publicKey?.clear()
+                this.encryptionKey = null
+                return
+            }
+
+            this.encryptionKey?.let { currentKey ->
+                // if current key is not null, compare with the passed key
+                if (
+                    !currentKey.privateKey.compare(encryptionKey.privateKey) ||
+                    !currentKey.publicKey.compare(encryptionKey.publicKey)
+                ) {
+
+                    // if provided key was not the same, clear the current key and set
+                    currentKey.privateKey.clear()
+                    currentKey.publicKey.clear()
+                    this.encryptionKey = encryptionKey
+                }
+
+                // otherwise do nothing
+
+            } ?: let {
+
+                // if no encryption key is set, set it to the provided key
+                this.encryptionKey = encryptionKey
+
+            }
         }
     }
 }

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationProcessor.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationProcessor.kt
@@ -119,10 +119,10 @@ internal class AuthenticationProcessor private constructor(
                             publicKey.value
                         )
 
-                        authenticationCoreManager.setEncryptionKey(key)
+//                        authenticationCoreManager.setEncryptionKey(key)
                         authenticationCoreManager.updateAuthenticationState(
                             AuthenticationState.NotRequired,
-                            null
+                            key
                         )
 
                         flowOf(AuthenticationResponse.Success.Key(request, key))
@@ -530,12 +530,12 @@ internal class AuthenticationProcessor private constructor(
                 when (request) {
                     is AuthenticationRequest.LogIn -> {
 
-                        authenticationCoreManager.getEncryptionKey() ?: let {
-                            authenticationCoreManager.setEncryptionKey(encryptionKey)
-                        }
+//                        authenticationCoreManager.getEncryptionKey() ?: let {
+//                            authenticationCoreManager.setEncryptionKey(encryptionKey)
+//                        }
 
                         authenticationCoreManager.updateAuthenticationState(
-                            AuthenticationState.NotRequired, null
+                            AuthenticationState.NotRequired, encryptionKey
                         )
                         responses.add(
                             AuthenticationResponse.Success.Authenticated(request)
@@ -560,9 +560,12 @@ internal class AuthenticationProcessor private constructor(
                     }
                     is AuthenticationRequest.GetEncryptionKey -> {
 
-                        authenticationCoreManager.getEncryptionKey() ?: let {
-                            authenticationCoreManager.setEncryptionKey(encryptionKey)
-                        }
+//                        authenticationCoreManager.getEncryptionKey() ?: let {
+//                            authenticationCoreManager.setEncryptionKey(encryptionKey)
+//                        }
+                        authenticationCoreManager.updateAuthenticationState(
+                            AuthenticationState.NotRequired, encryptionKey
+                        )
 
                         responses.add(
                             AuthenticationResponse.Success.Key(request, encryptionKey)


### PR DESCRIPTION
This PR refactors the `authentication-core` module by:
 - Modifying how the `EncryptionKey` is set. It is now set when calling the `updateAuthenticationState` method
 - Added a protected method for `onInitialLoginSuccess` such that inheritors can execute initialization of things using the `EncryptionKey` when the user has successfully logged in for the first time.
 - Removed ability for inheritors to set `AuthenticationState.NotRequired`.