### PR TITLE
Add supervisor scope for managing flow collection from lifecycle component

### DIFF
--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisorScope.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisorScope.kt
@@ -1,0 +1,26 @@
+package io.matthewnelson.android_feature_viewmodel.util
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+class OnStopSupervisorScope(owner: LifecycleOwner): DefaultLifecycleObserver {
+    private var supervisor = SupervisorJob()
+    private var scope = CoroutineScope(supervisor)
+
+    fun scope(): CoroutineScope =
+        scope
+
+    override fun onStop(owner: LifecycleOwner) {
+        supervisor.cancel()
+        supervisor = SupervisorJob().also {
+            scope = CoroutineScope(it)
+        }
+        super.onStop(owner)
+    }
+
+    init {
+        owner.lifecycle.addObserver(this)
+    }
+}


### PR DESCRIPTION
This PR adds the `OnStopSuervisorScope` class to the `android-feature-viewmodel` module. This is a helper class for stopping collection from a viewmodel (or other source) when the activity/fragment's lifecycle event `onStop`.