### PR TITLE
Modify/Add Extension functions

### DIFF
--- a/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/util/ViewExtensions.kt
+++ b/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/util/ViewExtensions.kt
@@ -26,22 +26,36 @@ inline fun Int.dpToPX(): Int =
 inline fun Int.pxToDp(): Int =
     (this / Resources.getSystem().displayMetrics.density).toInt()
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun View.invisibleIfTrue(boolean: Boolean) {
-    this.visibility = if (boolean) View.INVISIBLE else View.VISIBLE
-}
+inline val <T: View> T.visible: T
+    get() {
+        visibility = View.VISIBLE
+        return this
+    }
+
+inline val <T: View> T.invisible: T
+    get() {
+        visibility = View.INVISIBLE
+        return this
+    }
+
+inline val <T: View> T.gone: T
+    get() {
+        visibility = View.GONE
+        return this
+    }
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun View.invisibleIfFalse(boolean: Boolean) {
-    this.invisibleIfTrue(!boolean)
-}
+inline fun <T: View> T.invisibleIfTrue(boolean: Boolean): T =
+    if (boolean) invisible else visible
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun View.goneIfTrue(boolean: Boolean) {
-    this.visibility = if (boolean) View.GONE else View.VISIBLE
-}
+inline fun <T: View> T.invisibleIfFalse(boolean: Boolean): T =
+    invisibleIfTrue(!boolean)
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun View.goneIfFalse(boolean: Boolean) {
-    this.goneIfTrue(!boolean)
-}
+inline fun <T: View> T.goneIfTrue(boolean: Boolean): T =
+    if (boolean) gone else visible
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T: View> T.goneIfFalse(boolean: Boolean): T =
+    goneIfTrue(!boolean)

--- a/kotlin/crypto/crypto-common/src/main/java/io/matthewnelson/crypto_common/clazzes/UnencryptedByteArray.kt
+++ b/kotlin/crypto/crypto-common/src/main/java/io/matthewnelson/crypto_common/clazzes/UnencryptedByteArray.kt
@@ -31,8 +31,8 @@ inline fun UnencryptedByteArray.toUnencryptedCharArray(): UnencryptedCharArray =
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(UnencryptedDataAccess::class)
-inline fun UnencryptedByteArray.toUnencryptedString(): UnencryptedString =
-    UnencryptedString(value.toString(charset("UTF-8")).trim())
+inline fun UnencryptedByteArray.toUnencryptedString(trim: Boolean = true): UnencryptedString =
+    UnencryptedString(value.toString(charset("UTF-8")).let { if (trim) it.trim() else it})
 
 inline class UnencryptedByteArray(@property: UnencryptedDataAccess val value: ByteArray) {
 


### PR DESCRIPTION
This PR modifies the extension function for going from an `UnencryptedByteArray` -> `UnencryptedString` such that a constructor argument can be expressed whereby `trim()` operation will not be called on the resulting string by passing `false`.

It also adds some view extensions pertaining to visibility, and improves them with by generifying return types so user can chain calls.