### PR TITLE
FIX: OnStopSupervisorScope unable to reattach observer in fragment when navigating back

### DIFF
--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisorScope.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisorScope.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
-class OnStopSupervisorScope(owner: LifecycleOwner): DefaultLifecycleObserver {
+class OnStopSupervisorScope: DefaultLifecycleObserver {
     private var supervisor = SupervisorJob()
     private var scope = CoroutineScope(supervisor)
 
@@ -20,7 +20,11 @@ class OnStopSupervisorScope(owner: LifecycleOwner): DefaultLifecycleObserver {
         super.onStop(owner)
     }
 
-    init {
+    /**
+     * Call from fragment's onViewCreated
+     * */
+    fun observe(owner: LifecycleOwner): OnStopSupervisorScope {
         owner.lifecycle.addObserver(this)
+        return this
     }
 }


### PR DESCRIPTION
This PR modifies the `OnStopSupervisorScope` class such that the constructor argument is moved to a method which can be called in a fragment's `onViewCreated` override, in order to re-attach the observer.