### PR TITLE
REFACTOR: Fragment/Activity flow collection

### DIFF
--- a/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
+++ b/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
@@ -19,12 +19,13 @@ import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.viewbinding.ViewBinding
+import io.matthewnelson.android_feature_viewmodel.util.OnStopSupervisor
 import io.matthewnelson.concept_navigation.NavigationRequest
 import io.matthewnelson.feature_navigation.NavigationDriver
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 /**
  * Note, [VM] and [NVM] must be the same class (the [ViewModel]), otherwise a
@@ -48,6 +49,8 @@ abstract class NavigationActivity<
      * */
     protected abstract val navigationViewModel: NVM
 
+    protected val onStopSupervisor: OnStopSupervisor = OnStopSupervisor()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -55,7 +58,12 @@ abstract class NavigationActivity<
             "'viewModel' variable is not the same class as 'navigationActivityViewModel'"
         }
 
-        lifecycleScope.launchWhenStarted {
+        onStopSupervisor.observe(this)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        onStopSupervisor.scope().launch(navigationViewModel.dispatchers.mainImmediate) {
             navigationViewModel
                 .navigationDriver
                 .navigationRequestSharedFlow

--- a/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
+++ b/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationActivity.kt
@@ -63,7 +63,7 @@ abstract class NavigationActivity<
 
     override fun onStart() {
         super.onStart()
-        onStopSupervisor.scope().launch(navigationViewModel.dispatchers.mainImmediate) {
+        onStopSupervisor.scope.launch(navigationViewModel.dispatchers.mainImmediate) {
             navigationViewModel
                 .navigationDriver
                 .navigationRequestSharedFlow

--- a/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationViewModel.kt
+++ b/android/features/android-feature-activity/src/main/java/io/matthewnelson/android_feature_activity/NavigationViewModel.kt
@@ -16,8 +16,10 @@
 package io.matthewnelson.android_feature_activity
 
 import androidx.navigation.NavController
+import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import io.matthewnelson.feature_navigation.NavigationDriver
 
 interface NavigationViewModel<T: NavigationDriver<NavController>> {
     val navigationDriver: T
+    val dispatchers: CoroutineDispatchers
 }

--- a/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/base/BaseFragment.kt
+++ b/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/base/BaseFragment.kt
@@ -53,7 +53,7 @@ abstract class BaseFragment<
      * Called from [onStart] and cancelled from [onStop]
      * */
     protected open fun subscribeToViewStateFlow() {
-        onStopSupervisor.scope().launch(viewModel.mainImmediate) {
+        onStopSupervisor.scope.launch(viewModel.mainImmediate) {
             viewModel.collectViewState { viewState ->
                 if (currentViewState != viewState) {
                     currentViewState = viewState

--- a/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/base/BaseFragment.kt
+++ b/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/base/BaseFragment.kt
@@ -16,13 +16,15 @@
 package io.matthewnelson.android_feature_screens.ui.base
 
 import android.os.Bundle
+import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.lifecycleScope
 import androidx.viewbinding.ViewBinding
 import io.matthewnelson.android_feature_viewmodel.BaseViewModel
 import io.matthewnelson.android_feature_viewmodel.collectViewState
+import io.matthewnelson.android_feature_viewmodel.util.OnStopSupervisor
 import io.matthewnelson.concept_views.viewstate.ViewState
+import kotlinx.coroutines.launch
 
 abstract class BaseFragment<
         VS: ViewState<VS>,
@@ -32,23 +34,37 @@ abstract class BaseFragment<
 {
     protected abstract val viewModel: BVM
     protected abstract val binding: VB
+    protected val onStopSupervisor: OnStopSupervisor = OnStopSupervisor()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        onStopSupervisor.observe(viewLifecycleOwner)
+    }
+
+    override fun onStart() {
+        super.onStart()
         subscribeToViewStateFlow()
     }
 
     protected abstract suspend fun onViewStateFlowCollect(viewState: VS)
+    protected var currentViewState: VS? = null
 
     /**
-     * Called from [onCreate]. Must be mindful if overriding to lazily start things
-     * using lifecycleScope.launchWhenStarted
+     * Called from [onStart] and cancelled from [onStop]
      * */
     protected open fun subscribeToViewStateFlow() {
-        lifecycleScope.launchWhenStarted {
+        onStopSupervisor.scope().launch(viewModel.mainImmediate) {
             viewModel.collectViewState { viewState ->
-                onViewStateFlowCollect(viewState)
+                if (currentViewState != viewState) {
+                    currentViewState = viewState
+                    onViewStateFlowCollect(viewState)
+                }
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        currentViewState = null
     }
 }

--- a/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/motionlayout/MotionLayoutFragment.kt
+++ b/android/features/android-feature-screens/src/main/java/io/matthewnelson/android_feature_screens/ui/motionlayout/MotionLayoutFragment.kt
@@ -65,6 +65,7 @@ abstract class MotionLayoutFragment<
     protected abstract fun onViewCreatedRestoreMotionScene(viewState: MLVS, binding: VB)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        currentViewState = viewModel.currentViewState
         onViewCreatedRestoreMotionScene(viewModel.currentViewState, binding)
     }
 

--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/BaseViewModel.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/BaseViewModel.kt
@@ -16,10 +16,12 @@
 package io.matthewnelson.android_feature_viewmodel
 
 import androidx.lifecycle.ViewModel
+import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import io.matthewnelson.concept_views.viewstate.ViewState
 import io.matthewnelson.concept_views.viewstate.ViewStateContainer
 import io.matthewnelson.concept_views.viewstate.collect
 import io.matthewnelson.concept_views.viewstate.value
+import kotlinx.coroutines.CoroutineDispatcher
 
 suspend inline fun <VS: ViewState<VS>> BaseViewModel<VS>.collectViewState(
     crossinline action: suspend (value: VS) -> Unit
@@ -38,7 +40,8 @@ inline fun <VS: ViewState<VS>> BaseViewModel<VS>.updateViewState(viewState: VS) 
  * */
 abstract class BaseViewModel<
         VS: ViewState<VS>
-        >(initialViewState: VS): ViewModel()
+        >(val dispatchers: CoroutineDispatchers, initialViewState: VS)
+    : ViewModel(), CoroutineDispatchers by dispatchers
 {
     @Suppress("RemoveExplicitTypeArguments")
     open val viewStateContainer: ViewStateContainer<VS> by lazy {

--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/MotionLayoutViewModel.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/MotionLayoutViewModel.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.android_feature_viewmodel
 
 import io.matthewnelson.android_concept_views.MotionLayoutViewState
+import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import io.matthewnelson.concept_views.sideeffect.SideEffect
 
 /**
@@ -29,11 +30,11 @@ abstract class MotionLayoutViewModel<
         T,
         SE: SideEffect<T>,
         MLVS: MotionLayoutViewState<MLVS>
-        >(initialViewState: MLVS): SideEffectViewModel<
+        >(dispatchers: CoroutineDispatchers, initialViewState: MLVS): SideEffectViewModel<
         T,
         SE,
         MLVS
-        >(initialViewState)
+        >(dispatchers, initialViewState)
 {
 
     /**

--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/SideEffectViewModel.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/SideEffectViewModel.kt
@@ -15,6 +15,7 @@
 * */
 package io.matthewnelson.android_feature_viewmodel
 
+import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import io.matthewnelson.concept_views.sideeffect.SideEffect
 import io.matthewnelson.concept_views.sideeffect.SideEffectContainer
 import io.matthewnelson.concept_views.sideeffect.collect
@@ -40,9 +41,9 @@ abstract class SideEffectViewModel<
         T,
         SE: SideEffect<T>,
         VS: ViewState<VS>
-        >(initialViewState: VS): BaseViewModel<
+        >(dispatchers: CoroutineDispatchers, initialViewState: VS): BaseViewModel<
         VS
-        >(initialViewState)
+        >(dispatchers, initialViewState)
 {
     @Suppress("RemoveExplicitTypeArguments")
     open val sideEffectContainer: SideEffectContainer<T, SE> by lazy {

--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisor.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisor.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
-class OnStopSupervisorScope: DefaultLifecycleObserver {
+class OnStopSupervisor: DefaultLifecycleObserver {
     private var supervisor = SupervisorJob()
     private var scope = CoroutineScope(supervisor)
 
@@ -23,7 +23,7 @@ class OnStopSupervisorScope: DefaultLifecycleObserver {
     /**
      * Call from fragment's onViewCreated
      * */
-    fun observe(owner: LifecycleOwner): OnStopSupervisorScope {
+    fun observe(owner: LifecycleOwner): OnStopSupervisor {
         owner.lifecycle.addObserver(this)
         return this
     }

--- a/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisor.kt
+++ b/android/features/android-feature-viewmodel/src/main/java/io/matthewnelson/android_feature_viewmodel/util/OnStopSupervisor.kt
@@ -7,10 +7,8 @@ import kotlinx.coroutines.SupervisorJob
 
 class OnStopSupervisor: DefaultLifecycleObserver {
     private var supervisor = SupervisorJob()
-    private var scope = CoroutineScope(supervisor)
-
-    fun scope(): CoroutineScope =
-        scope
+    var scope = CoroutineScope(supervisor)
+        private set
 
     override fun onStop(owner: LifecycleOwner) {
         supervisor.cancel()

--- a/kotlin/concepts/concept-coroutines/src/main/java/io/matthewnelson/concept_coroutines/CoroutineDispatchers.kt
+++ b/kotlin/concepts/concept-coroutines/src/main/java/io/matthewnelson/concept_coroutines/CoroutineDispatchers.kt
@@ -22,10 +22,10 @@ import kotlinx.coroutines.CoroutineDispatcher
  * platforms. If that is the case, when extending [CoroutineDispatcher] initialize
  * [mainImmediate] with [kotlinx.coroutines.Dispatchers.Main]
  * */
-abstract class CoroutineDispatchers(
-    val default: CoroutineDispatcher,
-    val io: CoroutineDispatcher,
-    val main: CoroutineDispatcher,
-    val mainImmediate: CoroutineDispatcher,
+interface CoroutineDispatchers {
+    val default: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val main: CoroutineDispatcher
+    val mainImmediate: CoroutineDispatcher
     val unconfined: CoroutineDispatcher
-)
+}

--- a/kotlin/test/test-concept-coroutines/src/main/java/io/matthewnelson/test_concept_coroutines/CoroutineTestHelper.kt
+++ b/kotlin/test/test-concept-coroutines/src/main/java/io/matthewnelson/test_concept_coroutines/CoroutineTestHelper.kt
@@ -27,12 +27,12 @@ abstract class CoroutineTestHelper {
     protected val testDispatcher = TestCoroutineDispatcher()
 
     class TestCoroutineDispatchers(
-        default: CoroutineDispatcher,
-        io: CoroutineDispatcher,
-        main: CoroutineDispatcher,
-        mainImmediate: CoroutineDispatcher,
-        unconfined: CoroutineDispatcher
-    ): CoroutineDispatchers(default, io, main, mainImmediate, unconfined)
+        override val default: CoroutineDispatcher,
+        override val io: CoroutineDispatcher,
+        override val main: CoroutineDispatcher,
+        override val mainImmediate: CoroutineDispatcher,
+        override val unconfined: CoroutineDispatcher
+    ): CoroutineDispatchers
 
     protected val dispatchers: CoroutineDispatchers by lazy {
         TestCoroutineDispatchers(


### PR DESCRIPTION
This PR:
 - Refactors the `kotlin:concepts:concept-coroutines` module such that `CoroutineDispatchers` can now be used as a delegate by other classes.
 - Updates the `BaseViewModel` to require `CoroutineDispatchers` as a constructor argument.
 - Renames the `OnStopSupervisorScope` class to `OnStopSupervisor` to be better descriptive.
 - Instantiates `OnStopSupervisor` as a protected value in the `NavigationActivity` as well as the `BaseFragment`.
 - Refactors ViewState Flow collection to be started/stopped while screen is inactive
     - Fixes #3
     - Fixed #14 