### PR TITLE
Expose user PIN to do things with it (encrypt data, etc) when confirming the PIN

### DIFF
--- a/kotlin/concepts/authentication/concept-authentication/src/main/java/io/matthewnelson/concept_authentication/coordinator/AuthenticationRequest.kt
+++ b/kotlin/concepts/authentication/concept-authentication/src/main/java/io/matthewnelson/concept_authentication/coordinator/AuthenticationRequest.kt
@@ -17,11 +17,25 @@ package io.matthewnelson.concept_authentication.coordinator
 
 import io.matthewnelson.crypto_common.clazzes.Password
 
+abstract class ConfirmedPinListener {
+    /**
+     * Called from Dispatchers.Default
+     * */
+    abstract suspend fun doWithConfirmedPassword(password: Password)
+}
+
 sealed class AuthenticationRequest {
 
     abstract val priority: Int
 
-    class ConfirmPin: AuthenticationRequest() {
+    /**
+     * Sending a [ConfirmedPinListener] along with the request will give access to the
+     * user's PIN value after it has been confirmed, prior to the [AuthenticationResponse]
+     * being returned.
+     * */
+    class ConfirmPin(
+        val listener: ConfirmedPinListener? = null
+    ): AuthenticationRequest() {
         override val priority: Int = 3
     }
 

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationProcessor.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationProcessor.kt
@@ -554,6 +554,12 @@ internal class AuthenticationProcessor private constructor(
                                 )
                     }
                     is AuthenticationRequest.ConfirmPin -> {
+                        try {
+                            request
+                                .listener
+                                ?.doWithConfirmedPassword(Password(userInput.toCharArray()))
+                        } catch (e: Exception) {}
+
                         responses.add(
                             AuthenticationResponse.Success.Authenticated(request)
                         )


### PR DESCRIPTION
This PR adds the ability to do something with the user's PIN (such as encrypt data) from a `AuthenticationRequest.ConfirmPin`.