### PR TITLE
Fix command line build errors for KOpenSSL Unit Test Helper

### DIFF
--- a/kotlin/crypto/k-openssl/src/test/java/io/matthewnelson/k_openssl/KOpenSSLUnitTest.kt
+++ b/kotlin/crypto/k-openssl/src/test/java/io/matthewnelson/k_openssl/KOpenSSLUnitTest.kt
@@ -61,263 +61,301 @@ class KOpenSSLUnitTest: OpenSSLTestHelper() {
     @Test
     fun `encrypt with Kotlin is compat with OpenSSL decrypt`() =
         testDispatcher.runBlockingTest {
-            val encryptedResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_STRING),
-                testDispatcher
-            )
-            val decryptedResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = true,
-                stringToEcho = encryptedResultFromKotlin.value,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromOpenSSL!!)
+            script?.let {
+                val encryptedResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_STRING),
+                    testDispatcher
+                )
+                val decryptedResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = true,
+                    stringToEcho = encryptedResultFromKotlin.value,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromOpenSSL!!)
 
-            val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
-                testDispatcher
-            )
-            val decryptedMultiLineResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = true,
-                stringToEcho = encryptedMultiLineResultFromKotlin.value,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            Assert.assertEquals(UNENCRYPTED_MULTI_LINE_STRING, decryptedMultiLineResultFromOpenSSL!!)
+                val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
+                    testDispatcher
+                )
+                val decryptedMultiLineResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = true,
+                    stringToEcho = encryptedMultiLineResultFromKotlin.value,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_MULTI_LINE_STRING,
+                    decryptedMultiLineResultFromOpenSSL!!
+                )
 
-            val encryptedVeryLongStringResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_VERY_LONG_STRING),
-                testDispatcher
-            )
-            val decryptedVeryLongStringResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = true,
-                stringToEcho = encryptedVeryLongStringResultFromKotlin.value,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            Assert.assertEquals(UNENCRYPTED_VERY_LONG_STRING, decryptedVeryLongStringResultFromOpenSSL!!)
+                val encryptedVeryLongStringResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_VERY_LONG_STRING),
+                    testDispatcher
+                )
+                val decryptedVeryLongStringResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = true,
+                    stringToEcho = encryptedVeryLongStringResultFromKotlin.value,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_VERY_LONG_STRING,
+                    decryptedVeryLongStringResultFromOpenSSL!!
+                )
+            }
         }
 
     @Test
     fun `encrypt with OpenSSL is compat with Kotlin decrypt`() =
         testDispatcher.runBlockingTest {
-            val encryptedResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            val decryptedResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                EncryptedString(encryptedResultFromOpenSSL!!),
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromKotlin.value)
+            script?.let {
+                val encryptedResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                val decryptedResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    EncryptedString(encryptedResultFromOpenSSL!!),
+                    testDispatcher
+                )
+                Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromKotlin.value)
 
-            val encryptedMultiLineResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_MULTI_LINE_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            val decryptedMultiLineResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                EncryptedString(encryptedMultiLineResultFromOpenSSL!!),
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_MULTI_LINE_STRING, decryptedMultiLineResultFromKotlin.value)
+                val encryptedMultiLineResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_MULTI_LINE_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                val decryptedMultiLineResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    EncryptedString(encryptedMultiLineResultFromOpenSSL!!),
+                    testDispatcher
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_MULTI_LINE_STRING,
+                    decryptedMultiLineResultFromKotlin.value
+                )
 
-            val encryptedVeryLongStringResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_VERY_LONG_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            val decryptedVeryLongStringResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                EncryptedString(encryptedVeryLongStringResultFromOpenSSL!!),
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_VERY_LONG_STRING, decryptedVeryLongStringResultFromKotlin.value)
+                val encryptedVeryLongStringResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_VERY_LONG_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                val decryptedVeryLongStringResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    EncryptedString(encryptedVeryLongStringResultFromOpenSSL!!),
+                    testDispatcher
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_VERY_LONG_STRING,
+                    decryptedVeryLongStringResultFromKotlin.value
+                )
+            }
         }
 
     @Test
     fun `Kotlin encryption and decryption compat`() =
         testDispatcher.runBlockingTest {
-            val encryptedResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_STRING),
-                testDispatcher
-            )
-            val decryptedResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                encryptedResultFromKotlin,
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromKotlin.value)
+            script?.let {
+                val encryptedResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_STRING),
+                    testDispatcher
+                )
+                val decryptedResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    encryptedResultFromKotlin,
+                    testDispatcher
+                )
+                Assert.assertEquals(UNENCRYPTED_STRING, decryptedResultFromKotlin.value)
 
-            val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
-                testDispatcher
-            )
-            val decryptedMultiLineResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                encryptedMultiLineResultFromKotlin,
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_MULTI_LINE_STRING, decryptedMultiLineResultFromKotlin.value)
+                val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
+                    testDispatcher
+                )
+                val decryptedMultiLineResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    encryptedMultiLineResultFromKotlin,
+                    testDispatcher
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_MULTI_LINE_STRING,
+                    decryptedMultiLineResultFromKotlin.value
+                )
 
-            val encryptedVeryLongStringResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_VERY_LONG_STRING),
-                testDispatcher
-            )
-            val decryptedVeryLongStringResultFromKotlin = aes256cbc.decrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                encryptedVeryLongStringResultFromKotlin,
-                testDispatcher
-            )
-            Assert.assertEquals(UNENCRYPTED_VERY_LONG_STRING, decryptedVeryLongStringResultFromKotlin.value)
+                val encryptedVeryLongStringResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_VERY_LONG_STRING),
+                    testDispatcher
+                )
+                val decryptedVeryLongStringResultFromKotlin = aes256cbc.decrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    encryptedVeryLongStringResultFromKotlin,
+                    testDispatcher
+                )
+                Assert.assertEquals(
+                    UNENCRYPTED_VERY_LONG_STRING,
+                    decryptedVeryLongStringResultFromKotlin.value
+                )
+            }
         }
 
     @Test
     fun `incorrect password throws character coding exception on decrypt`() =
         testDispatcher.runBlockingTest {
-            val failMsg = "CharacterCodingException was not thrown on wrong password decrypt"
-            val encryptedResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_STRING),
-                testDispatcher
-            )
-
-            try {
-                aes256cbc.decrypt(
-                    Password((PASSWORD + "7").toCharArray()),
+            script?.let {
+                val failMsg = "CharacterCodingException was not thrown on wrong password decrypt"
+                val encryptedResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
                     HashIterations(HASH_ITERATIONS),
-                    encryptedResultFromKotlin,
+                    UnencryptedString(UNENCRYPTED_STRING),
                     testDispatcher
                 )
-                Assert.fail("$failMsg for Kotlin encrypted data")
-            } catch (e: CharacterCodingException) {}
 
-            val encryptedResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            try {
-                aes256cbc.decrypt(
-                    Password((PASSWORD + "7").toCharArray()),
-                    HashIterations(HASH_ITERATIONS),
-                    EncryptedString(encryptedResultFromOpenSSL!!),
-                    testDispatcher
+                try {
+                    aes256cbc.decrypt(
+                        Password((PASSWORD + "7").toCharArray()),
+                        HashIterations(HASH_ITERATIONS),
+                        encryptedResultFromKotlin,
+                        testDispatcher
+                    )
+                    Assert.fail("$failMsg for Kotlin encrypted data")
+                } catch (e: CharacterCodingException) {
+                }
+
+                val encryptedResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
                 )
-                Assert.fail("$failMsg for OpenSSL encrypted data")
-            } catch (e: CharacterCodingException) {}
+                try {
+                    aes256cbc.decrypt(
+                        Password((PASSWORD + "7").toCharArray()),
+                        HashIterations(HASH_ITERATIONS),
+                        EncryptedString(encryptedResultFromOpenSSL!!),
+                        testDispatcher
+                    )
+                    Assert.fail("$failMsg for OpenSSL encrypted data")
+                } catch (e: CharacterCodingException) {}
+            }
         }
 
     @Test
     fun `incorrect hash iterations throws character encoding exception on decrypt`() =
         testDispatcher.runBlockingTest {
-            val failMsg = "CharacterCodingException was not thrown on wrong hash iteration decrypt"
-            val encryptedResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_STRING),
-                testDispatcher
-            )
-            try {
-                aes256cbc.decrypt(
+            script?.let {
+                val failMsg =
+                    "CharacterCodingException was not thrown on wrong hash iteration decrypt"
+                val encryptedResultFromKotlin = aes256cbc.encrypt(
                     Password(PASSWORD.toCharArray()),
-                    HashIterations(HASH_ITERATIONS - 1),
-                    encryptedResultFromKotlin,
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_STRING),
                     testDispatcher
                 )
-                Assert.fail("$failMsg for Kotlin encrypted data")
-            } catch (e: CharacterCodingException) {}
+                try {
+                    aes256cbc.decrypt(
+                        Password(PASSWORD.toCharArray()),
+                        HashIterations(HASH_ITERATIONS - 1),
+                        encryptedResultFromKotlin,
+                        testDispatcher
+                    )
+                    Assert.fail("$failMsg for Kotlin encrypted data")
+                } catch (e: CharacterCodingException) {
+                }
 
-            val encryptedResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            try {
-                aes256cbc.decrypt(
-                    Password(PASSWORD.toCharArray()),
-                    HashIterations(HASH_ITERATIONS - 1),
-                    EncryptedString(encryptedResultFromOpenSSL!!),
-                    testDispatcher
+                val encryptedResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
                 )
-                Assert.fail("$failMsg for OpenSSL encrypted data")
-            } catch (e: CharacterCodingException) {}
+                try {
+                    aes256cbc.decrypt(
+                        Password(PASSWORD.toCharArray()),
+                        HashIterations(HASH_ITERATIONS - 1),
+                        EncryptedString(encryptedResultFromOpenSSL!!),
+                        testDispatcher
+                    )
+                    Assert.fail("$failMsg for OpenSSL encrypted data")
+                } catch (e: CharacterCodingException) {
+                }
+            }
         }
 
     @Test
     fun `isSalted method properly detects a salted, encrypted string`() =
         testDispatcher.runBlockingTest {
-            val encryptedResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_STRING),
-                testDispatcher
-            )
-            val encryptedResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            Assert.assertTrue(encryptedResultFromKotlin.value.isSalted)
-            Assert.assertTrue(encryptedResultFromOpenSSL!!.isSalted)
-            Assert.assertTrue(KOpenSSL.SALTED.toByteArray().encodeBase64().isSalted)
-            Assert.assertFalse(KOpenSSL.SALTED.dropLast(1).toByteArray().encodeBase64().isSalted)
-            Assert.assertFalse(KOpenSSL.SALTED.isSalted)
+            script?.let {
+                val encryptedResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_STRING),
+                    testDispatcher
+                )
+                val encryptedResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                Assert.assertTrue(encryptedResultFromKotlin.value.isSalted)
+                Assert.assertTrue(encryptedResultFromOpenSSL!!.isSalted)
+                Assert.assertTrue(KOpenSSL.SALTED.toByteArray().encodeBase64().isSalted)
+                Assert.assertFalse(
+                    KOpenSSL.SALTED.dropLast(1).toByteArray().encodeBase64().isSalted
+                )
+                Assert.assertFalse(KOpenSSL.SALTED.isSalted)
 
-            val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
-                Password(PASSWORD.toCharArray()),
-                HashIterations(HASH_ITERATIONS),
-                UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
-                testDispatcher
-            )
-            val encryptedMultiLineResultFromOpenSSL = openSSLExecute(
-                printOutput = false,
-                decrypt = false,
-                stringToEcho = UNENCRYPTED_MULTI_LINE_STRING,
-                iterations = HASH_ITERATIONS,
-                password = PASSWORD
-            )
-            Assert.assertTrue(encryptedMultiLineResultFromKotlin.value.isSalted)
-            Assert.assertTrue(encryptedMultiLineResultFromOpenSSL!!.isSalted)
-            Assert.assertTrue(KOpenSSL.SALTED.toByteArray().encodeBase64().isSalted)
-            Assert.assertFalse(KOpenSSL.SALTED.dropLast(1).toByteArray().encodeBase64().isSalted)
-            Assert.assertFalse(KOpenSSL.SALTED.isSalted)
+                val encryptedMultiLineResultFromKotlin = aes256cbc.encrypt(
+                    Password(PASSWORD.toCharArray()),
+                    HashIterations(HASH_ITERATIONS),
+                    UnencryptedString(UNENCRYPTED_MULTI_LINE_STRING),
+                    testDispatcher
+                )
+                val encryptedMultiLineResultFromOpenSSL = openSSLExecute(
+                    printOutput = false,
+                    decrypt = false,
+                    stringToEcho = UNENCRYPTED_MULTI_LINE_STRING,
+                    iterations = HASH_ITERATIONS,
+                    password = PASSWORD
+                )
+                Assert.assertTrue(encryptedMultiLineResultFromKotlin.value.isSalted)
+                Assert.assertTrue(encryptedMultiLineResultFromOpenSSL!!.isSalted)
+                Assert.assertTrue(KOpenSSL.SALTED.toByteArray().encodeBase64().isSalted)
+                Assert.assertFalse(
+                    KOpenSSL.SALTED.dropLast(1).toByteArray().encodeBase64().isSalted
+                )
+                Assert.assertFalse(KOpenSSL.SALTED.isSalted)
+            }
         }
 }


### PR DESCRIPTION
This PR modifies the OpenSSL Test Helper class to soft fail tests in case the person performing a command line build does not have Openssl installed, and instead posts a warning.